### PR TITLE
Extend russian translations & add py.typed for strict mypy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently, we have translated pydantic v1.10.2 errors to the following languages
 * `fr`: French. 87/87.
 * `it`: Italian. 87/87.
 * `nl`: Dutch. 87/87.
-* `ru`: Russian. 70/87.
+* `ru`: Russian. 82/87.
 
 Need more languages? Contributions are welcome!
 

--- a/locales/ru.po
+++ b/locales/ru.po
@@ -65,7 +65,7 @@ msgstr "значение должно быть корректным IPv4 адр�
 
 #: pydantic_translations/_messages.py:31
 msgid "value is not a valid IPv4 interface"
-msgstr ""
+msgstr "значение должно быть корректным IPv4 интерфейсом"
 
 #: pydantic_translations/_messages.py:32
 msgid "value is not a valid IPv4 network"
@@ -77,7 +77,7 @@ msgstr "значение должно быть корректным IPv4 или 
 
 #: pydantic_translations/_messages.py:34
 msgid "value is not a valid IPv4 or IPv6 interface"
-msgstr ""
+msgstr "значение должно быть корректным IPv4 или IPv6 интерфейсом"
 
 #: pydantic_translations/_messages.py:35
 msgid "value is not a valid IPv4 or IPv6 network"
@@ -89,7 +89,7 @@ msgstr "значение должно быть корректным IPv6 адр�
 
 #: pydantic_translations/_messages.py:37
 msgid "value is not a valid IPv6 interface"
-msgstr ""
+msgstr "значение должно быть корректным IPv6 интерфейсом"
 
 #: pydantic_translations/_messages.py:38
 msgid "value is not a valid IPv6 network"
@@ -133,12 +133,12 @@ msgstr "значение должно быть словарём"
 #: pydantic_translations/_messages.py:58
 #, python-brace-format
 msgid "{value} is not a valid Enum instance"
-msgstr ""
+msgstr "{value} должно быть элементом перечисления"
 
 #: pydantic_translations/_messages.py:59
 #, python-brace-format
 msgid "value is not a valid enumeration member; permitted: {permitted}"
-msgstr ""
+msgstr "значение должно быть элементом перечисления; допускаются: {permitted}"
 
 #: pydantic_translations/_messages.py:60
 msgid "value is not a valid float"
@@ -155,7 +155,7 @@ msgstr "значение должно быть хэшируемым"
 #: pydantic_translations/_messages.py:63
 #, python-brace-format
 msgid "{value} is not a valid IntEnum instance"
-msgstr ""
+msgstr "{value} должно быть элементом целочисленного перечисления"
 
 #: pydantic_translations/_messages.py:64
 msgid "value is not a valid integer"
@@ -253,14 +253,14 @@ msgstr "в сумме должно быть не больше {max_digits} ци�
 #: pydantic_translations/_messages.py:85
 #, python-brace-format
 msgid "ensure that there are no more than {decimal_places} decimal places"
-msgstr ""
+msgstr "должно быть не больше {decimal_places} цифр после запятой"
 
 #: pydantic_translations/_messages.py:87
 #, python-brace-format
 msgid ""
 "ensure that there are no more than {whole_digits} digits before the decimal "
 "point"
-msgstr ""
+msgstr "в целой части должно быть не больше {whole_digits} цифр"
 
 #: pydantic_translations/_messages.py:88
 #, python-brace-format
@@ -371,19 +371,19 @@ msgstr "некорректная длина кортежа {actual_length}, ож
 #: pydantic_translations/_messages.py:115
 #, python-brace-format
 msgid "URL invalid, extra characters found after valid URL: {extra!r}"
-msgstr ""
+msgstr "недопустимый URL, после допустимого URL находятся дополнительные символы: {extra!r}"
 
 #: pydantic_translations/_messages.py:116
 msgid "URL host invalid"
-msgstr ""
+msgstr "некорректный URL хост"
 
 #: pydantic_translations/_messages.py:116
 msgid "URL host invalid, top level domain required"
-msgstr ""
+msgstr "некорректный URL хост, домен верхнего уровня должен быть указан"
 
 #: pydantic_translations/_messages.py:117
 msgid "URL port invalid, port cannot exceed 65535"
-msgstr "некорретный URL порт, номер порта должен быть не больше 65535"
+msgstr "недопустимый URL порт, номер порта должен быть не больше 65535"
 
 #: pydantic_translations/_messages.py:118
 msgid "invalid or missing URL scheme"
@@ -391,7 +391,7 @@ msgstr "URL должен содержать корректную схему"
 
 #: pydantic_translations/_messages.py:118
 msgid "URL scheme not permitted"
-msgstr ""
+msgstr "указание URL схемы не разрешено"
 
 #: pydantic_translations/_messages.py:119
 msgid "userinfo required in URL but missing"


### PR DESCRIPTION
Hi! I'd like to use this lib in one of my projects, but I needed some of the missing translations and the py.typed file (for [strict mypy](https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-library-stubs-or-py-typed-marker)). So here is the PR to add all of that & a bit more translations from the ones I could understand. Let me know if any fixes (version bump?) are needed here